### PR TITLE
Fix stale discussion cache after posting comments

### DIFF
--- a/workers/model-verify-api/src/index.js
+++ b/workers/model-verify-api/src/index.js
@@ -362,9 +362,11 @@ function normalizedCacheUrl(urlValue, baseUrl) {
 }
 
 function cacheKeyForUrl(request, urlValue, tag, origin = request.headers.get('origin') || '') {
+  // Cache data is identical across origins, so the cache key is intentionally
+  // origin-independent. Keying by origin previously split GET reads and POST
+  // purges into mismatched buckets, leaving stale entries that never cleared.
   const url = new URL(normalizedCacheUrl(urlValue, request.url));
   url.searchParams.set('__mv_cache', tag);
-  url.searchParams.set('__mv_origin', origin || 'none');
   return new Request(url.toString(), { method: 'GET' });
 }
 
@@ -443,19 +445,10 @@ async function cachedJson(request, env, ctx, tag, producer, timing = null) {
   const now = Date.now();
   const forceRefresh = cacheRefreshRequested(request);
   if (forceRefresh) {
-    const endProducer = timeSpan(timing, 'producer');
-    try {
-      return json(await producer(), {
-        headers: {
-          ...corsHeaders(request, env),
-          'cache-control': 'no-store',
-          'x-model-verify-cache': 'refresh',
-          ...(timingHeader(timing) ? { 'server-timing': timingHeader(timing) } : {})
-        }
-      });
-    } finally {
-      endProducer();
-    }
+    // Produce fresh data AND write it back to cache, so a forced refresh leaves
+    // the cache current. Otherwise the next non-forced read would serve a stale
+    // entry that the forced fetch never updated.
+    return produceCachedJson(request, env, ctx, tag, memoryKey, edgeKey, producer, 'refresh', timing);
   }
   const memoryEntry = jsonMemoryCache.get(memoryKey);
   if (memoryEntry && now < memoryEntry.expiresAt) {


### PR DESCRIPTION
## 问题
登录后在汇总排行里点开某份报告发表评论，评论不显示，手动刷新也看不到，要等边缘缓存 TT(最长 1 小时)过期才出现。

## 根因（JSON 缓存层的两个叠加问题）
1. **缓存 key 含 `__mv_origin` 维度**（取自请求的 Origin 头）。GET 读取与 POST 评论后的 purge 落在不同 origin 桶里，导致 purge 清不掉读取方命中的那条缓存。讨论数据跨 origin 完全一致，故去掉该维度。
2. **`_refresh` 强刷路径只返回 no-store 新数据、不回写缓存**，下一次非强刷读取又命中旧缓存。现在改为走 `produceCachedJson` 回填缓存，同时仍对客户端返回 `no-store`。

## 验证
已 `wrangler deploy` 上线（Version `e7ad5811`）。线上实测：
- 普通 GET → `x-model-verify-cache: miss` + `max-age=3600`
- 强刷 GET → `x-model-verify-cache: refresh` + `no-store`（并回写缓存）

> 注：后端 Worker 已直接部署生效，此 PR 用于同步源码与记录变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)